### PR TITLE
removing tabs in info.yml

### DIFF
--- a/profiles/purdue_starter_kit/purdue_starter_kit.info.yml
+++ b/profiles/purdue_starter_kit/purdue_starter_kit.info.yml
@@ -51,7 +51,7 @@ dependencies:
   - editor
   - ckeditor
 # Contrib modules added to /modules/contrib
-	- admin_toolbar
+  - admin_toolbar
 
 # List any themes that should be installed as part of the installation
 # profile installation.


### PR DESCRIPTION
because a yml file can't include tabs. Must use spaces. haha